### PR TITLE
Fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "webpack-dev-server": "^3.11.2"
   },
   "peerDependencies": {
-    "react": ">=16.0.0",
-    "react-dom": ">=16.0.0"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,20 +25,20 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@types/node": "^14.14.41",
+    "@types/react": "^17.0.2",
+    "@types/react-dom": "^17.0.2",
     "typescript": "^4.2.4",
     "ts-loader": "^9.0.0",
     "tslib": "^2.2.0",
     "css-loader": "^5.2.2",
     "style-loader": "^2.0.0",
-    "react": ">=16.0.0",
-    "react-dom": ">=16.0.0"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@types/eslint": "^7.2.10",
     "@types/eslint-plugin-prettier": "^3.1.0",
-    "@types/node": "^14.14.41",
-    "@types/react": "^17.0.3",
-    "@types/react-dom": "^17.0.3",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "eslint": "^7.24.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,17 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "module": "commonjs",
     "jsx": "react",
     "sourceMap": true,
     "strict": true,
     "noUnusedLocals": true,
+    "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true
   }


### PR DESCRIPTION
Add in `"skipLibCheck": true,` since the build is currently failing trying to resolve conflicting react type versions.
I have tried resolving the versions and etc, but need to use the workaround instead.

The only problem is that the type safety is not perfectly maintained, but we're not really going to modify this repo alot.

https://stackoverflow.com/questions/52399839/duplicate-identifier-librarymanagedattributes